### PR TITLE
Write to socket only if it is open

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -111,7 +111,7 @@ module.exports = {
     proxyReq.on('error', onOutgoingError);
     proxyReq.on('response', function (res) {
       // if upgrade event isn't going to happen, close the socket
-      if (!res.upgrade && !socket.destroyed) {
+      if (!res.upgrade && socket.readyState === socket.OPEN && !socket.destroyed) {
         socket.write(createHttpHeader('HTTP/' + res.httpVersion + ' ' + res.statusCode + ' ' + res.statusMessage, res.headers));
         res.pipe(socket);
       }


### PR DESCRIPTION
Partially fixes cypress-io/cypress#17288

This patch ensures that we write to a socket that is, in fact, open. This prevents exceptions from being thrown, like evidenced in cypress-io/cypress#17288.

After merge, this needs to be bundled into cypress to fix cypress-io/cypress#17288 fully.